### PR TITLE
Fix code scanning alert no. 2: Database query built from user-controlled sources

### DIFF
--- a/.github/scripts/close-release-bug-report-issue.ts
+++ b/.github/scripts/close-release-bug-report-issue.ts
@@ -93,8 +93,8 @@ async function retrieveOpenBugReportIssue(
   | undefined
 > {
   const retrieveOpenBugReportIssueQuery = `
-  query RetrieveOpenBugReportIssue {
-    search(query: "repo:${repoOwner}/${repoName} type:issue is:open in:title v${releaseVersionNumber} Bug Report", type: ISSUE, first: 1) {
+  query RetrieveOpenBugReportIssue($releaseVersionNumber: String!) {
+    search(query: "repo:${repoOwner}/${repoName} type:issue is:open in:title v$releaseVersionNumber Bug Report", type: ISSUE, first: 1) {
       nodes {
         ... on Issue {
           id
@@ -112,7 +112,9 @@ async function retrieveOpenBugReportIssue(
         title: string;
       }[];
     };
-  } = await octokit.graphql(retrieveOpenBugReportIssueQuery);
+  } = await octokit.graphql(retrieveOpenBugReportIssueQuery, {
+    releaseVersionNumber,
+  });
 
   const bugReportIssues = retrieveOpenBugReportIssueQueryResult?.search?.nodes;
 


### PR DESCRIPTION
Fixes [https://github.com/OKEAMAH/metamask-extension/security/code-scanning/2](https://github.com/OKEAMAH/metamask-extension/security/code-scanning/2)

To fix the problem, we should use parameterized queries to safely embed the `releaseVersionNumber` into the GraphQL query. This approach ensures that the user-controlled data is treated as a literal value and not as part of the query syntax.

1. Modify the `retrieveOpenBugReportIssue` function to use a parameterized query.
2. Update the GraphQL query string to include a variable for the `releaseVersionNumber`.
3. Pass the `releaseVersionNumber` as a variable to the `octokit.graphql` method.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
